### PR TITLE
One any of object

### DIFF
--- a/src/tests/data/anyof_object.json
+++ b/src/tests/data/anyof_object.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "required": [
+    "ob"
+  ],
+  "properties": {
+    "ob": {
+      "type": "object",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "name",
+            "human_readable_value"
+          ],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "human_readable_value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "id",
+            "machine_readable_value"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "machine_readable_value": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/tests/data/oneof_object.json
+++ b/src/tests/data/oneof_object.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "required": [
+    "ob"
+  ],
+  "properties": {
+    "ob": {
+      "type": "object",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "name",
+            "human_readable_value"
+          ],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "human_readable_value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "id",
+            "machine_readable_value"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "machine_readable_value": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/tests/test_default_fake.py
+++ b/src/tests/test_default_fake.py
@@ -13,6 +13,16 @@ def test_fake_anyof(TestData):
     for d in fake_data:
         assert isinstance(d, str) or isinstance(d, float)
 
+def test_fake_anyof_object(TestData):
+    with open(TestData / f"anyof_object.json", "r") as file:
+        schema = json.load(file)
+    p = JSF(schema)
+
+    fake_data = [p.generate() for _ in range(10)]
+    for d in fake_data:
+        assert isinstance(d, dict)
+        assert ("name" in d["ob"]) or ("id" in d["ob"])
+
 def test_fake_oneof(TestData):
     with open(TestData / f"oneof.json", "r") as file:
         schema = json.load(file)
@@ -21,6 +31,17 @@ def test_fake_oneof(TestData):
     fake_data = [p.generate() for _ in range(10)]
     for d in fake_data:
         assert isinstance(d, bool) or isinstance(d, str)
+
+
+def test_fake_oneof_object(TestData):
+    with open(TestData / f"oneof_object.json", "r") as file:
+        schema = json.load(file)
+    p = JSF(schema)
+
+    fake_data = [p.generate() for _ in range(10)]
+    for d in fake_data:
+        assert isinstance(d, dict)
+        assert ("name" in d["ob"]) or ("id" in d["ob"])
 
 def test_fake_boolean(TestData):
     with open(TestData / f"boolean.json", "r") as file:


### PR DESCRIPTION
entity of type "object" that includes "oneOf" " or "anyOf" but no "properties" falls through the cracks.

This PR fixes this.

```
Traceback (most recent call last):
  File "jsf/src/jsf/schema_types/object.py", line 40, in generate
    return super().generate(context)
  File "jsf/src/jsf/schema_types/base.py", line 49, in generate
    raise ProviderNotSetException()
jsf.schema_types.base.ProviderNotSetException

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "jsf/src/jsf/schema_types/object.py", line 40, in generate
    return super().generate(context)
  File "jsf/src/jsf/schema_types/base.py", line 49, in generate
    raise ProviderNotSetException()
jsf.schema_types.base.ProviderNotSetException

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "jsf/src/jsf/schema_types/object.py", line 40, in generate
    return super().generate(context)
  File "jsf/src/jsf/schema_types/base.py", line 49, in generate
    raise ProviderNotSetException()
jsf.schema_types.base.ProviderNotSetException

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "mockdatageneration/prototype/test.py", line 19, in <module>
    data = faker.generate()
  File "jsf/src/jsf/parser.py", line 143, in generate
    return self.root.generate(context=self.context)
  File "jsf/src/jsf/schema_types/object.py", line 42, in generate
    return {o.name: o.generate(context) for o in self.properties if self.should_keep(o.name)}
  File "jsf/src/jsf/schema_types/object.py", line 42, in <dictcomp>
    return {o.name: o.generate(context) for o in self.properties if self.should_keep(o.name)}
  File "jsf/src/jsf/schema_types/object.py", line 42, in generate
    return {o.name: o.generate(context) for o in self.properties if self.should_keep(o.name)}
  File "jsf/src/jsf/schema_types/object.py", line 42, in <dictcomp>
    return {o.name: o.generate(context) for o in self.properties if self.should_keep(o.name)}
  File "jsf/src/jsf/schema_types/object.py", line 42, in generate
    return {o.name: o.generate(context) for o in self.properties if self.should_keep(o.name)}
TypeError: 'NoneType' object is not iterable
```